### PR TITLE
container started and exited time metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,26 @@ podman_container_created_seconds{id="642490688d9c"} 1.655859511e+09
 podman_container_created_seconds{id="ad36e85960a1"} 1.655859858e+09
 podman_container_created_seconds{id="dda983cc3ecf"} 1.655859839e+09
 
+# HELP podman_container_started_seconds Container started time in unixtime.
+# TYPE podman_container_started_seconds gauge
+podman_container_started_seconds{id="19286a13dc23"} 1.659253804e+09
+podman_container_started_seconds{id="22e3d69be889"} -6.21355968e+10
+podman_container_started_seconds{id="390ac740fa80"} 1.66064284e+09
+podman_container_started_seconds{id="482113b805f7"} 1.659253804e+09
+podman_container_started_seconds{id="642490688d9c"} 1.660642996e+09
+podman_container_started_seconds{id="ad36e85960a1"} 1.66064284e+09
+podman_container_started_seconds{id="dda983cc3ecf"} 1.66064284e+09
+
+# HELP podman_container_exited_seconds Container exited time in unixtime.
+# TYPE podman_container_exited_seconds gauge
+podman_container_exited_seconds{id="19286a13dc23"} 1.659253805e+09
+podman_container_exited_seconds{id="22e3d69be889"} -6.21355968e+10
+podman_container_exited_seconds{id="390ac740fa80"} 1.660643511e+09
+podman_container_exited_seconds{id="482113b805f7"} 1.659253805e+09
+podman_container_exited_seconds{id="642490688d9c"} 1.659253804e+09
+podman_container_exited_seconds{id="ad36e85960a1"} 1.660643511e+09
+podman_container_exited_seconds{id="dda983cc3ecf"} 1.660643511e+09
+
 # HELP podman_container_mem_limit_bytes Container memory limit.
 # TYPE podman_container_mem_limit_bytes gauge
 podman_container_mem_limit_bytes{id="19286a13dc23"} 9.713655808e+09

--- a/collector/container.go
+++ b/collector/container.go
@@ -10,6 +10,8 @@ type containerCollector struct {
 	info        typedDesc
 	state       typedDesc
 	created     typedDesc
+	started     typedDesc
+	exited      typedDesc
 	pids        typedDesc
 	cpu         typedDesc
 	cpuSystem   typedDesc
@@ -48,6 +50,20 @@ func NewContainerStatsCollector(logger log.Logger) (Collector, error) {
 			prometheus.NewDesc(
 				prometheus.BuildFQName(namespace, "container", "created_seconds"),
 				"Container creation time in unixtime.",
+				[]string{"id"}, nil,
+			), prometheus.GaugeValue,
+		},
+		started: typedDesc{
+			prometheus.NewDesc(
+				prometheus.BuildFQName(namespace, "container", "started_seconds"),
+				"Container started time in unixtime.",
+				[]string{"id"}, nil,
+			), prometheus.GaugeValue,
+		},
+		exited: typedDesc{
+			prometheus.NewDesc(
+				prometheus.BuildFQName(namespace, "container", "exited_seconds"),
+				"Container exited time in unixtime.",
 				[]string{"id"}, nil,
 			), prometheus.GaugeValue,
 		},
@@ -129,6 +145,8 @@ func (c *containerCollector) Update(ch chan<- prometheus.Metric) error {
 		ch <- c.info.mustNewConstMetric(1, rep.ID, rep.Name, rep.Image, rep.Ports, rep.PodID)
 		ch <- c.state.mustNewConstMetric(float64(rep.State), rep.ID)
 		ch <- c.created.mustNewConstMetric(float64(rep.Created), rep.ID)
+		ch <- c.started.mustNewConstMetric(float64(rep.Started), rep.ID)
+		ch <- c.exited.mustNewConstMetric(float64(rep.Exited), rep.ID)
 	}
 
 	statReports, err := pdcs.ContainersStats()

--- a/pdcs/container.go
+++ b/pdcs/container.go
@@ -20,6 +20,8 @@ type Container struct {
 	Name    string
 	Image   string
 	Created int64
+	Started int64
+	Exited  int64
 	Ports   string
 	State   int
 }
@@ -60,6 +62,8 @@ func Containers() ([]Container, error) {
 			Name:    rep.Names[0],
 			Image:   rep.Image,
 			Created: rep.Created.Unix(),
+			Started: rep.StartedAt,
+			Exited:  rep.ExitedAt,
 			State:   conReporter{rep}.state(),
 			Ports:   conReporter{rep}.ports(),
 		})


### PR DESCRIPTION
Added container started and exited time metrics and it will cover #19 feature request.
 
```shell
podman_container_started_seconds{id="19286a13dc23"} 1.659253804e+09
podman_container_started_seconds{id="22e3d69be889"} -6.21355968e+10

podman_container_exited_seconds{id="19286a13dc23"} 1.659253805e+09
podman_container_exited_seconds{id="22e3d69be889"} -6.21355968e+10
```
Signed-off-by: Navid Yaghoobi <navidys@fedoraproject.org>