### PR TITLE
convert pod/container/image labels to prometheus metrics variable labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,20 +24,23 @@ Usage:
   prometheus-podman-exporter [flags]
 
 Flags:
-  -a, --collector.enable-all           Enable all collectors by default.
-  -i, --collector.image                Enable image collector.
-  -n, --collector.network              Enable network collector.
-  -o, --collector.pod                  Enable pod collector.
-  -s, --collector.system               Enable system collector.
-  -v, --collector.volume               Enable volume collector.
-  -d, --debug                          Set log level to debug.
-  -h, --help                           help for podman_exporter
-      --version                        Print version and exit.
-  -e, --web.disable-exporter-metrics   Exclude metrics about the exporter itself (promhttp_*, process_*, go_*).
-  -l, --web.listen-address string      Address on which to expose metrics and web interface. (default ":9882")
-  -m, --web.max-requests int           Maximum number of parallel scrape requests. Use 0 to disable (default 40)
-  -p, --web.telemetry-path string      Path under which to expose metrics. (default "/metrics")
-
+  -a, --collector.enable-all                  Enable all collectors by default.
+  -i, --collector.image                       Enable image collector.
+  -n, --collector.network                     Enable network collector.
+  -o, --collector.pod                         Enable pod collector.
+  -b, --collector.store_labels                Convert pod/container/image labels on prometheus metrics for each pod/container/image.
+  -s, --collector.system                      Enable system collector.
+  -v, --collector.volume                      Enable volume collector.
+  -w, --collector.whitelisted_labels string   Comma separated list of pod/container/image labels to be converted
+                                              to labels on prometheus metrics for each pod/container/image.
+                                              collector.store_labels must be set to false for this to take effect.
+  -d, --debug                                 Set log level to debug.
+  -h, --help                                  help for prometheus-podman-exporter
+      --version                               Print version and exit.
+  -e, --web.disable-exporter-metrics          Exclude metrics about the exporter itself (promhttp_*, process_*, go_*).
+  -l, --web.listen-address string             Address on which to expose metrics and web interface. (default ":9882")
+  -m, --web.max-requests int                  Maximum number of parallel scrape requests. Use 0 to disable (default 40)
+  -p, --web.telemetry-path string             Path under which to expose metrics. (default "/metrics")
 ```
 
 By default only container collector is enabled, in order to enable all collectors use `--collector.enable-all` or use `--collector.enable-<name>` flag to enable other collector.

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -87,4 +87,10 @@ func init() {
 		"Enable network collector.")
 	rootCmd.Flags().BoolP("collector.system", "s", false,
 		"Enable system collector.")
+	rootCmd.Flags().BoolP("collector.store_labels", "b", false,
+		"Convert pod/container/image labels on prometheus metrics for each pod/container/image.")
+	rootCmd.Flags().StringP("collector.whitelisted_labels", "w", "",
+		"Comma separated list of pod/container/image labels to be converted\n"+
+			"to labels on prometheus metrics for each pod/container/image.\n"+
+			"collector.store_labels must be set to false for this to take effect.")
 }

--- a/collector/pod.go
+++ b/collector/pod.go
@@ -22,11 +22,7 @@ func init() {
 func NewPodStatsCollector(logger log.Logger) (Collector, error) {
 	return &podCollector{
 		info: typedDesc{
-			prometheus.NewDesc(
-				prometheus.BuildFQName(namespace, "pod", "info"),
-				"Pod information",
-				[]string{"id", "name", "infra_id"}, nil,
-			), prometheus.GaugeValue,
+			nil, prometheus.GaugeValue,
 		},
 		state: typedDesc{
 			prometheus.NewDesc(
@@ -61,11 +57,50 @@ func (c *podCollector) Update(ch chan<- prometheus.Metric) error {
 	}
 
 	for _, rep := range reports {
-		ch <- c.info.mustNewConstMetric(1, rep.ID, rep.Name, rep.InfraID)
+		infoMetric, infoValues := c.getPodInfoDesc(rep)
+		c.info.desc = infoMetric
+
+		ch <- c.info.mustNewConstMetric(1, infoValues...)
 		ch <- c.state.mustNewConstMetric(float64(rep.State), rep.ID)
 		ch <- c.numOfContainers.mustNewConstMetric(float64(rep.NumOfContainers), rep.ID)
 		ch <- c.created.mustNewConstMetric(float64(rep.Created), rep.ID)
 	}
 
 	return nil
+}
+
+func (c *podCollector) getPodInfoDesc(rep pdcs.Pod) (*prometheus.Desc, []string) {
+	podLabels := []string{"id", "name", "infra_id"}
+	podLabelsValue := []string{rep.ID, rep.Name, rep.InfraID}
+
+	extraLabels, extraValues := c.getExtraLabelsAndValues(rep)
+
+	podLabels = append(podLabels, extraLabels...)
+	podLabelsValue = append(podLabelsValue, extraValues...)
+
+	infoDesc := prometheus.NewDesc(
+		prometheus.BuildFQName(namespace, "pod", "info"),
+		"Pod information",
+		podLabels, nil,
+	)
+
+	return infoDesc, podLabelsValue
+}
+
+func (c *podCollector) getExtraLabelsAndValues(rep pdcs.Pod) ([]string, []string) {
+	extraLabels := make([]string, 0)
+	extraValues := make([]string, 0)
+
+	for label, value := range rep.Labels {
+		validLabel := sanitizeLabelName(label)
+		if storeLabels {
+			extraLabels = append(extraLabels, validLabel)
+			extraValues = append(extraValues, value)
+		} else if whitelistContains(label) {
+			extraLabels = append(extraLabels, validLabel)
+			extraValues = append(extraValues, value)
+		}
+	}
+
+	return extraLabels, extraValues
 }

--- a/collector/utils.go
+++ b/collector/utils.go
@@ -1,0 +1,36 @@
+package collector
+
+import (
+	"regexp"
+	"strings"
+	"sync"
+)
+
+var (
+	collectorSync     sync.Once
+	storeLabels       bool
+	whitelistedLabels []string
+	invalidNameCharRE = regexp.MustCompile(`[^a-zA-Z0-9_]`)
+)
+
+// RegisterVariableLabels sets storeLabels or whiteListed labels to be converted to metrics.
+func RegisterVariableLabels(storeLabel bool, whiteListed string) {
+	collectorSync.Do(func() {
+		storeLabels = storeLabel
+		whitelistedLabels = strings.Split(whiteListed, ",")
+	})
+}
+
+func sanitizeLabelName(name string) string {
+	return invalidNameCharRE.ReplaceAllString(name, "_")
+}
+
+func whitelistContains(text string) bool {
+	for _, item := range whitelistedLabels {
+		if item == text {
+			return true
+		}
+	}
+
+	return false
+}

--- a/exporter/exporter.go
+++ b/exporter/exporter.go
@@ -74,7 +74,7 @@ func Start(cmd *cobra.Command, args []string) error {
 	level.Info(logger).Log("msg", "Listening on", "address", webListen)
 
 	server := &http.Server{
-		ReadHeaderTimeout: 3 * time.Second,
+		ReadHeaderTimeout: 3 * time.Second, // nolint:gomnd
 	}
 	serverSystemd := false
 	serverConfigFile := ""
@@ -99,6 +99,18 @@ func setEnabledCollectors(cmd *cobra.Command) error {
 	if err != nil {
 		return err
 	}
+
+	storeLabels, err := cmd.Flags().GetBool("collector.store_labels")
+	if err != nil {
+		return err
+	}
+
+	whiteListedLabels, err := cmd.Flags().GetString("collector.whitelisted_labels")
+	if err != nil {
+		return err
+	}
+
+	collector.RegisterVariableLabels(storeLabels, whiteListedLabels)
 
 	if enableAll {
 		enList = append(enList, "pod")

--- a/pdcs/container.go
+++ b/pdcs/container.go
@@ -18,6 +18,7 @@ type Container struct {
 	ID       string
 	PodID    string // if container is part of pod
 	Name     string
+	Labels   map[string]string
 	Image    string
 	Created  int64
 	Started  int64
@@ -63,6 +64,7 @@ func Containers() ([]Container, error) {
 			ExitCode: rep.ExitCode,
 			State:    conReporter{rep}.state(),
 			Ports:    conReporter{rep}.ports(),
+			Labels:   rep.Labels,
 		})
 	}
 

--- a/pdcs/image.go
+++ b/pdcs/image.go
@@ -16,6 +16,7 @@ type Image struct {
 	Tag        string
 	Created    int64
 	Size       int64
+	Labels     map[string]string
 }
 
 // Images returns list of images (Image).
@@ -39,6 +40,7 @@ func Images() ([]Image, error) {
 					Tag:        tag,
 					Size:       rep.Size,
 					Created:    rep.Created,
+					Labels:     rep.Labels,
 				})
 			}
 		} else {
@@ -49,6 +51,7 @@ func Images() ([]Image, error) {
 				Tag:        "<none>",
 				Created:    rep.Created,
 				Size:       rep.Size,
+				Labels:     rep.Labels,
 			})
 		}
 	}

--- a/pdcs/pod.go
+++ b/pdcs/pod.go
@@ -10,6 +10,7 @@ type Pod struct {
 	ID              string
 	InfraID         string
 	Name            string
+	Labels          map[string]string
 	Created         int64
 	State           int
 	NumOfContainers int
@@ -29,6 +30,7 @@ func Pods() ([]Pod, error) {
 			ID:              getID(rep.Id),
 			InfraID:         getID(rep.InfraId),
 			Name:            rep.Name,
+			Labels:          rep.Labels,
 			Created:         rep.Created.Unix(),
 			NumOfContainers: len(rep.Containers),
 			State:           podReporter{rep}.status(),


### PR DESCRIPTION
Converting pod/container/image labels to variable labels for podman_<pod|container|image>_info metrics.

To support this feature, two new command options has been added:

- **--collector.store_labels**: Convert pod/container/image labels on prometheus metrics for each pod/container/image
- **--collector.whitelisted_labels string**: Comma separated list of pod/container/image labels to be converted to labels on prometheus metrics for each pod/container/image, collector.store_labels must be set to false for this to take effect.

Example output
```shell
podman_container_info{id="72c08cae0be3",image="docker.io/library/busybox:latest",label02="value02",label03="value03",name="busybox02",pod_id="",ports=""} 1

podman_image_info{id="2bdf8a106d1e",io_buildah_version="1.27.0",parent_id="",repository="localhost/podman-pause",tag="4.2.1-1662580673"} 1

podman_pod_info{id="23038034708e",infra_id="bd7627e4d928",label01="value01",label02="value02",name="pod01"} 1
```

Signed-off-by: Navid Yaghoobi <navidys@fedoraproject.org>