### PR TITLE
Add support for HTTPS & authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ Flags:
   -d, --debug                                 Set log level to debug.
   -h, --help                                  help for prometheus-podman-exporter
       --version                               Print version and exit.
+      --web.config.file string                [EXPERIMENTAL] Path to configuration file that can enable TLS or authentication.
   -e, --web.disable-exporter-metrics          Exclude metrics about the exporter itself (promhttp_*, process_*, go_*).
   -l, --web.listen-address string             Address on which to expose metrics and web interface. (default ":9882")
   -m, --web.max-requests int                  Maximum number of parallel scrape requests. Use 0 to disable (default 40)
@@ -50,6 +51,10 @@ By default only container collector is enabled, in order to enable all collector
 ```shell
 $ ./bin/prometheus-podman-exporter --collector.enable-all
 ```
+
+The exporter uses plain HTTP without any form of authentication to expose the metrics by default.
+Use `--web.config.file` with a configuration file to use TLS for confidentiality and/or to enable authentication.
+Visit [this page](https://github.com/prometheus/exporter-toolkit/blob/master/docs/web-configuration.md) for more information about the syntax of the configuration file.
 
 ## Collectors
 The table below list all existing collector and their description.

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -67,6 +67,8 @@ func init() {
 		"Set log level to debug.")
 	rootCmd.Flags().BoolP("version", "", false,
 		"Print version and exit.")
+	rootCmd.Flags().StringP("web.config.file", "", "",
+		"[EXPERIMENTAL] Path to configuration file that can enable TLS or authentication.")
 	rootCmd.Flags().StringP("web.listen-address", "l", ":9882",
 		"Address on which to expose metrics and web interface.")
 	rootCmd.Flags().StringP("web.telemetry-path", "p", "/metrics",

--- a/exporter/exporter.go
+++ b/exporter/exporter.go
@@ -52,6 +52,11 @@ func Start(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	webConfigFile, err := cmd.Flags().GetString("web.config.file")
+	if err != nil {
+		return err
+	}
+
 	logger := promlog.New(promlogConfig)
 
 	if err := setEnabledCollectors(cmd); err != nil {
@@ -77,13 +82,12 @@ func Start(cmd *cobra.Command, args []string) error {
 		ReadHeaderTimeout: 3 * time.Second, // nolint:gomnd
 	}
 	serverSystemd := false
-	serverConfigFile := ""
 	serverWebListen := []string{webListen}
 
 	toolkitFlag := new(web.FlagConfig)
 	toolkitFlag.WebSystemdSocket = &serverSystemd
 	toolkitFlag.WebListenAddresses = &serverWebListen
-	toolkitFlag.WebConfigFile = &serverConfigFile
+	toolkitFlag.WebConfigFile = &webConfigFile
 
 	if err := web.ListenAndServe(server, toolkitFlag, logger); err != nil {
 		return err


### PR DESCRIPTION
This adds support for HTTPS and authentication using the `--web.config.file` flag provided by the [exporter_toolkit](https://github.com/prometheus/exporter-toolkit).

See [this page](https://github.com/prometheus/exporter-toolkit/blob/master/docs/web-configuration.md) for more info on the syntax used in the configuration file and [this file](https://github.com/prometheus/exporter-toolkit/blob/master/docs/web-config.yml) for an actual example.

Fixes #90.