### PR TITLE
Feature/get images digests and repositories

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,12 +257,12 @@ podman_pod_created_seconds{id="d05cda23085a"} 1.655489348e+09
 ```shell
 # HELP podman_image_info Image information.
 # TYPE podman_image_info gauge
-podman_image_info{id="48565a8e6250",parent_id="",repository="docker.io/bitnami/prometheus",tag="latest"} 1
-podman_image_info{id="62aedd01bd85",parent_id="",repository="docker.io/library/busybox",tag="latest"} 1
-podman_image_info{id="75c013514322",parent_id="",repository="docker.io/library/sonarqube",tag="latest"} 1
-podman_image_info{id="a45fa0117c2b",parent_id="",repository="localhost/podman-pause",tag="4.1.0-1651853754"} 1
-podman_image_info{id="b260a49eebf9",parent_id="",repository="docker.io/library/httpd",tag="latest"} 1
-podman_image_info{id="c4b778290339",parent_id="b260a49eebf9",repository="docker.io/grafana/grafana",tag="latest"} 1
+podman_image_info{digest="sha256:4d7fdebe2a853aceb15019554b56e58055f7a746c0b4095eec869d5b6c11987e",id="48565a8e6250",parent_id="",repository="docker.io/bitnami/prometheus",tag="latest"} 1
+podman_image_info{digest="sha256:6d9ac9237a84afe1516540f40a0fafdc86859b2141954b4d643af7066d598b74",id="62aedd01bd85",parent_id="",repository="docker.io/library/busybox",tag="latest"} 1
+podman_image_info{digest="sha256:548f3d4246cda60c311a035620c26ea8fb21b3abc870c5806626a32ef936982b",id="75c013514322",parent_id="",repository="docker.io/library/sonarqube",tag="latest"} 1
+podman_image_info{digest="sha256:218169c5590870bb95c06e9f7e80ded58f6644c1974b0ca7f2c3405b74fc3b57",id="a45fa0117c2b",parent_id="",repository="localhost/podman-pause",tag="4.1.0-1651853754"} 1
+podman_image_info{digest="sha256:ba846154ade27292d216cce2d21f1c7e589f3b66a4a643bff0cdd348efd17aa3",id="b260a49eebf9",parent_id="",repository="docker.io/library/httpd",tag="latest"} 1
+podman_image_info{digest="sha256:7567a7c70a3c1d75aeeedc968d1304174a16651e55a60d1fb132a05e1e63a054",id="c4b778290339",parent_id="b260a49eebf9",repository="docker.io/grafana/grafana",tag="latest"} 1
 
 # HELP podman_image_created_seconds Image creation time in unixtime.
 # TYPE podman_image_created_seconds gauge

--- a/collector/image.go
+++ b/collector/image.go
@@ -27,14 +27,14 @@ func NewImageStatsCollector(logger log.Logger) (Collector, error) {
 			prometheus.NewDesc(
 				prometheus.BuildFQName(namespace, "image", "size"),
 				"Image size",
-				[]string{"id", "repository", "tag"}, nil,
+				[]string{"id", "repository", "tag", "digest"}, nil,
 			), prometheus.GaugeValue,
 		},
 		created: typedDesc{
 			prometheus.NewDesc(
 				prometheus.BuildFQName(namespace, "image", "created_seconds"),
 				"Image creation time in unixtime.",
-				[]string{"id", "repository", "tag"}, nil,
+				[]string{"id", "repository", "tag", "digest"}, nil,
 			), prometheus.GaugeValue,
 		},
 		logger: logger,
@@ -53,16 +53,16 @@ func (c *imageCollector) Update(ch chan<- prometheus.Metric) error {
 		c.info.desc = infoMetric
 		ch <- c.info.mustNewConstMetric(1, infoValues...)
 
-		ch <- c.size.mustNewConstMetric(float64(rep.Size), rep.ID, rep.Repository, rep.Tag)
-		ch <- c.created.mustNewConstMetric(float64(rep.Created), rep.ID, rep.Repository, rep.Tag)
+		ch <- c.size.mustNewConstMetric(float64(rep.Size), rep.ID, rep.Repository, rep.Tag, rep.Digest)
+		ch <- c.created.mustNewConstMetric(float64(rep.Created), rep.ID, rep.Repository, rep.Tag, rep.Digest)
 	}
 
 	return nil
 }
 
 func (c *imageCollector) getImageInfoDesc(rep pdcs.Image) (*prometheus.Desc, []string) {
-	imageLabels := []string{"id", "parent_id", "repository", "tag"}
-	imageLabelsValue := []string{rep.ID, rep.ParentID, rep.Repository, rep.Tag}
+	imageLabels := []string{"id", "parent_id", "repository", "tag", "digest"}
+	imageLabelsValue := []string{rep.ID, rep.ParentID, rep.Repository, rep.Tag, rep.Digest}
 
 	extraLabels, extraValues := c.getExtraLabelsAndValues(rep)
 

--- a/collector/image.go
+++ b/collector/image.go
@@ -27,14 +27,14 @@ func NewImageStatsCollector(logger log.Logger) (Collector, error) {
 			prometheus.NewDesc(
 				prometheus.BuildFQName(namespace, "image", "size"),
 				"Image size",
-				[]string{"id", "repository", "tag", "digest"}, nil,
+				[]string{"id", "repository", "tag"}, nil,
 			), prometheus.GaugeValue,
 		},
 		created: typedDesc{
 			prometheus.NewDesc(
 				prometheus.BuildFQName(namespace, "image", "created_seconds"),
 				"Image creation time in unixtime.",
-				[]string{"id", "repository", "tag", "digest"}, nil,
+				[]string{"id", "repository", "tag"}, nil,
 			), prometheus.GaugeValue,
 		},
 		logger: logger,

--- a/pdcs/image.go
+++ b/pdcs/image.go
@@ -25,6 +25,7 @@ type Image struct {
 	Tag        string
 	Created    int64
 	Size       int64
+	Digest     string
 	Labels     map[string]string
 }
 
@@ -70,6 +71,7 @@ func updateImages() {
 					Tag:        tag,
 					Size:       rep.Size,
 					Created:    rep.Created,
+					Digest:     rep.Digest,
 					Labels:     rep.Labels,
 				})
 			}
@@ -81,6 +83,7 @@ func updateImages() {
 				Tag:        "<none>",
 				Created:    rep.Created,
 				Size:       rep.Size,
+				Digest:     rep.Digest,
 				Labels:     rep.Labels,
 			})
 		}


### PR DESCRIPTION
This Pull Request adds a new label on the podman_image_info metric : the sha256 Digest of the image

This is a more secure way to distinguish image when the tag might be overwritten.

With the digest, it is possible to identify the image in a registry even if the tag has been reused on a new image.