### PR TITLE
fix exporter panic when using cli store_labels option

### DIFF
--- a/collector/container.go
+++ b/collector/container.go
@@ -191,7 +191,7 @@ func (c *containerCollector) getContainerInfoDesc(rep pdcs.Container) (*promethe
 	containerLabels := []string{"id", "name", "image", "ports", "pod_id", "pod_name"}
 	containerLabelsValue := []string{rep.ID, rep.Name, rep.Image, rep.Ports, rep.PodID, rep.PodName}
 
-	extraLabels, extraValues := c.getExtraLabelsAndValues(rep)
+	extraLabels, extraValues := c.getExtraLabelsAndValues(containerLabels, rep)
 
 	containerLabels = append(containerLabels, extraLabels...)
 	containerLabelsValue = append(containerLabelsValue, extraValues...)
@@ -205,11 +205,18 @@ func (c *containerCollector) getContainerInfoDesc(rep pdcs.Container) (*promethe
 	return infoDesc, containerLabelsValue
 }
 
-func (c *containerCollector) getExtraLabelsAndValues(rep pdcs.Container) ([]string, []string) {
+func (c *containerCollector) getExtraLabelsAndValues(
+	collectorLabels []string,
+	rep pdcs.Container,
+) ([]string, []string) {
 	extraLabels := make([]string, 0)
 	extraValues := make([]string, 0)
 
 	for label, value := range rep.Labels {
+		if slicesContains(collectorLabels, label) {
+			continue
+		}
+
 		validLabel := sanitizeLabelName(label)
 		if storeLabels {
 			extraLabels = append(extraLabels, validLabel)

--- a/collector/image.go
+++ b/collector/image.go
@@ -64,7 +64,7 @@ func (c *imageCollector) getImageInfoDesc(rep pdcs.Image) (*prometheus.Desc, []s
 	imageLabels := []string{"id", "parent_id", "repository", "tag", "digest"}
 	imageLabelsValue := []string{rep.ID, rep.ParentID, rep.Repository, rep.Tag, rep.Digest}
 
-	extraLabels, extraValues := c.getExtraLabelsAndValues(rep)
+	extraLabels, extraValues := c.getExtraLabelsAndValues(imageLabels, rep)
 
 	imageLabels = append(imageLabels, extraLabels...)
 	imageLabelsValue = append(imageLabelsValue, extraValues...)
@@ -78,11 +78,15 @@ func (c *imageCollector) getImageInfoDesc(rep pdcs.Image) (*prometheus.Desc, []s
 	return infoDesc, imageLabelsValue
 }
 
-func (c *imageCollector) getExtraLabelsAndValues(rep pdcs.Image) ([]string, []string) {
+func (c *imageCollector) getExtraLabelsAndValues(collectorLabels []string, rep pdcs.Image) ([]string, []string) {
 	extraLabels := make([]string, 0)
 	extraValues := make([]string, 0)
 
 	for label, value := range rep.Labels {
+		if slicesContains(collectorLabels, label) {
+			continue
+		}
+
 		validLabel := sanitizeLabelName(label)
 		if storeLabels {
 			extraLabels = append(extraLabels, validLabel)

--- a/collector/pod.go
+++ b/collector/pod.go
@@ -73,7 +73,7 @@ func (c *podCollector) getPodInfoDesc(rep pdcs.Pod) (*prometheus.Desc, []string)
 	podLabels := []string{"id", "name", "infra_id"}
 	podLabelsValue := []string{rep.ID, rep.Name, rep.InfraID}
 
-	extraLabels, extraValues := c.getExtraLabelsAndValues(rep)
+	extraLabels, extraValues := c.getExtraLabelsAndValues(podLabels, rep)
 
 	podLabels = append(podLabels, extraLabels...)
 	podLabelsValue = append(podLabelsValue, extraValues...)
@@ -87,11 +87,15 @@ func (c *podCollector) getPodInfoDesc(rep pdcs.Pod) (*prometheus.Desc, []string)
 	return infoDesc, podLabelsValue
 }
 
-func (c *podCollector) getExtraLabelsAndValues(rep pdcs.Pod) ([]string, []string) {
+func (c *podCollector) getExtraLabelsAndValues(collectorLabels []string, rep pdcs.Pod) ([]string, []string) {
 	extraLabels := make([]string, 0)
 	extraValues := make([]string, 0)
 
 	for label, value := range rep.Labels {
+		if slicesContains(collectorLabels, label) {
+			continue
+		}
+
 		validLabel := sanitizeLabelName(label)
 		if storeLabels {
 			extraLabels = append(extraLabels, validLabel)

--- a/collector/utils.go
+++ b/collector/utils.go
@@ -34,3 +34,13 @@ func whitelistContains(text string) bool {
 
 	return false
 }
+
+func slicesContains(list []string, value string) bool {
+	for _, item := range list {
+		if item == strings.ToLower(value) {
+			return true
+		}
+	}
+
+	return false
+}


### PR DESCRIPTION
Fix exporter panic when using store_labels cli options.
store_labels will add containers/pods/images labels to metric labels, however if the label name is same as constant names then it will cause a panic with following error: 

`panic: duplicate label names in constant and variable labels for metric`