### PR TITLE
Fix userns option for rootless unix socket use case in `install.md`

### DIFF
--- a/install.md
+++ b/install.md
@@ -34,7 +34,7 @@ prometheus-podman-exporter is using go v1.17 or above.
 
     ```shell
     $ systemctl start --user podman.socket
-    $ podman run -e CONTAINER_HOST=unix:///run/podman/podman.sock -v $XDG_RUNTIME_DIR/podman/podman.sock:/run/podman/podman.sock -p 9882:9882 --userns=keep-id --security-opt label=disable quay.io/navidys/prometheus-podman-exporter
+    $ podman run -e CONTAINER_HOST=unix:///run/podman/podman.sock -v $XDG_RUNTIME_DIR/podman/podman.sock:/run/podman/podman.sock -p 9882:9882 --userns=keep-id:uid=65534 --security-opt label=disable quay.io/navidys/prometheus-podman-exporter
     ```
 
 * Using unix socket (root):


### PR DESCRIPTION
Given that the container runs as nobody user (with uid 65534 by default) and host uid, which is most likely not 65534, should map to container's uid 65534