### PR TITLE
create dedicated systemd user service unit

### DIFF
--- a/contrib/systemd/user/prometheus-podman-exporter.service
+++ b/contrib/systemd/user/prometheus-podman-exporter.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=Prometheus exporter for podman (v4) machine
+[Service]
+Restart=on-failure
+EnvironmentFile=-/etc/sysconfig/prometheus-podman-exporter
+ExecStart=/usr/bin/prometheus-podman-exporter $PODMAN_EXPORTER_OPTS
+ExecReload=/bin/kill -HUP $MAINPID
+TimeoutStopSec=20s
+SendSIGKILL=no
+[Install]
+WantedBy=default.target

--- a/prometheus-podman-exporter.spec.rpkg
+++ b/prometheus-podman-exporter.spec.rpkg
@@ -59,7 +59,7 @@ install -dp %{buildroot}%{_userunitdir}
 install -p ./bin/%{name} %{buildroot}%{_bindir}
 install -Dpm0644 ./contrib/systemd/%{name}.sysconfig %{buildroot}%{_sysconfdir}/sysconfig/%{name}
 install -Dpm0644 ./contrib/systemd/%{name}.service %{buildroot}%{_unitdir}/%{name}.service
-install -Dpm0644 ./contrib/systemd/%{name}.service %{buildroot}%{_userunitdir}/%{name}.service
+install -Dpm0644 ./contrib/systemd/user/%{name}.service %{buildroot}%{_userunitdir}/%{name}.service
 
 pushd %{buildroot}%{_unitdir}
 ln -s %{name}.service %{shortname}.service


### PR DESCRIPTION
Same systemd service unit file was being used for system and user which works fine for system service but for user service it causes a problem when a user enables the unit. As install target is set to `multi-user.target` which doesn't exist for user, it prints a warning and doesn't function as expected.

So instead create seperate user service unit, which changes its install target to `default.target`.