### PR TITLE
modify runtimeVersion to return first line

### DIFF
--- a/pdcs/system.go
+++ b/pdcs/system.go
@@ -39,7 +39,7 @@ func SystemInfo() (System, error) {
 func (r reportInfo) runtimeVersion() string {
 	runtime := strings.Split(r.Host.OCIRuntime.Version, ":")[0]
 	runtime = strings.ReplaceAll(runtime, "commit", "")
-	runtime = strings.Trim(runtime, "\n")
+	runtime = strings.Split(runtime, "\n")[0]
 
 	return runtime
 }


### PR DESCRIPTION
runtimeVersion() is returning invalid version :

```
# HELP podman_system_runtime_version Podman system runtime version.
# TYPE podman_system_runtime_version gauge
podman_system_runtime_version{version="runc version 1.1.12\nspec"} 1
```

Proposed change returns valid version : 
```
# HELP podman_system_runtime_version Podman system runtime version.
# TYPE podman_system_runtime_version gauge
podman_system_runtime_version{version="runc version 1.1.12"} 1
```