### PR TITLE
Remove BUILDTAG btrfs_noversion as no longer effective

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,8 +12,7 @@ SELINUXOPT ?= $(shell test -x /usr/sbin/selinuxenabled && selinuxenabled && echo
 BUILDFLAGS := -mod=vendor
 BUILDTAGS ?= \
 	$(shell hack/systemd_tag.sh) \
-	$(shell hack/btrfs_installed_tag.sh) \
-	$(shell hack/btrfs_tag.sh)
+	$(shell hack/btrfs_installed_tag.sh)
 
 VERSION = $(shell cat VERSION  | grep VERSION | cut -d'=' -f2)
 REVISION = $(shell cat VERSION  | grep REVISION | cut -d'=' -f2)

--- a/hack/btrfs_tag.sh
+++ b/hack/btrfs_tag.sh
@@ -1,7 +1,0 @@
-#!/usr/bin/env bash
-${CPP:-${CC:-cc} -E} ${CPPFLAGS} - > /dev/null 2> /dev/null << EOF
-#include <btrfs/version.h>
-EOF
-if test $? -ne 0 ; then
-	echo btrfs_noversion
-fi


### PR DESCRIPTION
refer to https://github.com/containers/storage/pull/2308

Should I remove it in rpm file as well? I wasn't sure if it is needed in RHEL 9, so didn't mess with it